### PR TITLE
Adds DataSourceDelegator to support multiple data sources

### DIFF
--- a/src/Hosting/Api/Client.php
+++ b/src/Hosting/Api/Client.php
@@ -13,13 +13,19 @@ use GuzzleHttp\Client as GuzzleClient;
 class Client implements DataSourceInterface {
 
   /**
+   * @var DataSourceInterface
+   */
+  protected $delegator;
+
+  /**
    * @var FactoryInterface
    */
   protected $factory;
 
-  function __construct(GuzzleClient $client, FactoryInterface $factory) {
+  function __construct(GuzzleClient $client, FactoryInterface $factory, DataSourceInterface $delegator = null) {
     $this->client($client);
     $this->factory = $factory;
+    $this->delegator = $delegator;
   }
 
   /**
@@ -64,7 +70,7 @@ class Client implements DataSourceInterface {
    */
   protected function createObjectType($type, array $data = []) {
     if (empty($data['dataSource'])) {
-      $data['dataSource'] = $this;
+      $data['dataSource'] = $this->delegator ? $this->delegator : $this;
     }
     return $this->factory->createObjectType($type, $data);
   }

--- a/src/Hosting/DataSourceDelegator.php
+++ b/src/Hosting/DataSourceDelegator.php
@@ -1,0 +1,242 @@
+<?php
+
+/**
+ * @file
+ * Contains \Acquia\Platform\Cloud\Hosting\DataSourceDelegator.
+ *
+ * Based on code originally distributed inside the Acquia Support ToolsBundle
+ * Copyright (c) 2014-2015 Acquia, Inc.
+ */
+
+namespace Acquia\Platform\Cloud\Hosting;
+
+/**
+ * Integrates with cloud hosting data via one or more data sources.
+ */
+class DataSourceDelegator implements DataSourceInterface
+{
+    protected $dataSources = array();
+    protected $dataSourceCount = 0;
+
+    /**
+     * Delegate methods to the data source implementation(s).
+     *
+     * Iterate through available data sources until a valid result is received.
+     * A \RuntimeException is thrown if no data source provides the method.
+     *
+     * @param string $name A DataSourceInterface method name
+     * @param array|null $arguments An array of method arguments, or null.
+     *
+     * @return mixed|null
+     *
+     * @throws \RuntimeException
+     */
+    protected function delegate($name, $arguments)
+    {
+        $result = null;
+        $exceptions = array();
+        $dataSources = array_values($this->dataSources);
+        foreach ($dataSources as $dataSource) {
+            $class = get_class($dataSource);
+            try {
+                if (method_exists($dataSource, $name)) {
+                    $result = call_user_func_array(
+                        array($dataSource, $name),
+                        $arguments
+                    );
+                } else {
+                    throw new \RuntimeException("No such method '{$name}'.");
+                }
+            } catch (\RuntimeException $exception) {
+                $exceptions[$class] = $exception;
+                continue;
+            }
+            break;
+        }
+        if (count($exceptions) >= count($dataSources)) {
+            $error = "No successful delegate found for method '{$name}'. Exceptions caught:\n";
+            /**
+             * @var string $sourceName
+             * @var \RuntimeException $exception
+             */
+            foreach ($exceptions as $sourceName => $exception) {
+                $error .= sprintf(" * %s: %s\n", $sourceName, $exception->getMessage());
+            }
+            throw new \RuntimeException($error);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Adds a Data Source implementation
+     *
+     * @param DataSourceInterface $dataSource An Acquia Cloud hosting data source.
+     * @param int $weight Controls the order data sources are attempted in.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function addDataSource(DataSourceInterface $dataSource, $weight = 0)
+    {
+        if (!is_integer($weight)) {
+            throw new \InvalidArgumentException("Weight must be an integer.");
+        }
+
+        $index = ($weight * 10) + $this->dataSourceCount;
+        $this->dataSources[$index] = $dataSource;
+        ksort($this->dataSources, SORT_NUMERIC);
+        $this->dataSourceCount++;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliases()
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createDomain($site_id, $env, $domain)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSites()
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteDomain($site_id, $env, $domain)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogStream($site_id, $name)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableLiveDev($site_id, $name)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPhpProcs($site_id, $env, $server)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTasks($site_id)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function purgeDomainCache($site_id, $env, $domain)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTask($site_id, $task_id)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDomain($site_id, $env, $domain)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getServers($site_id, $env)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDomains($site_id, $env)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enableLiveDev($site_id, $name)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getServer($site_id, $env, $server)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSite($site_id)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEnvs($site_id)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEnv($site_id, $name)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function install($site_id, $env, $type, $source)
+    {
+        return $this->delegate(__FUNCTION__, func_get_args());
+    }
+}

--- a/tests/DelegationTest.php
+++ b/tests/DelegationTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @file
+ * Contains Acquia\Platform\Cloud\Tests\DelegationTest
+ */
+
+namespace Acquia\Platform\Cloud\Tests;
+
+use Acquia\Platform\Cloud\Hosting\Api\Client;
+use Acquia\Platform\Cloud\Hosting\DataSourceDelegator;
+use Acquia\Platform\Cloud\Hosting\Factory;
+
+
+class DelegationTest extends \PHPUnit_Framework_TestCase
+{
+    protected function getFullDataSource($delegator, $fullDelegate = null)
+    {
+        if (!$fullDelegate) {
+            $fullDelegate = new GuzzleTestClient();
+        }
+        return new Client($fullDelegate, new Factory(), $delegator);
+    }
+
+    protected function getPartialDataSource($delegator, $partialDelegate = null)
+    {
+        if (!$partialDelegate) {
+            $partialDelegate = new PartialDataSourceClient();
+        }
+        return new Client($partialDelegate, new Factory(), $delegator);
+    }
+
+    public function testSites() {
+        $guzzle = new GuzzleTestClient();
+        $delegator = new DataSourceDelegator();
+        $delegator->addDataSource($this->getPartialDataSource($delegator));
+        $delegator->addDataSource($this->getFullDataSource($delegator, $guzzle));
+        $return = $guzzle->get('sites.json')->json();
+        $this->assertEquals($return, $delegator->getSites()->getData());
+    }
+
+    public function testSite() {
+        $guzzle = new GuzzleTestClient();
+        $delegator = new DataSourceDelegator();
+        $delegator->addDataSource($this->getPartialDataSource($delegator));
+        $delegator->addDataSource($this->getFullDataSource($delegator, $guzzle));
+        $return = $guzzle->get('sites/{site}.json')->json();
+        $site = $delegator->getSites()[0];
+        $this->assertEquals($return, $site->getData());
+        $this->assertEquals($return['title'], $site->getTitle());
+        $this->assertEquals($return['name'], $site->getName());
+        $this->assertEquals($return['production_mode'], $site->getProductionMode());
+        $this->assertEquals($return['unix_username'], $site->getUnixUsername());
+        $this->assertEquals($return['vcs_type'], $site->getVcsType());
+        $this->assertEquals($return['vcs_url'], $site->getVcsUrl());
+    }
+
+    public function testTasks() {
+        $guzzle = new GuzzleTestClient();
+        $delegator = new DataSourceDelegator();
+        $delegator->addDataSource($this->getPartialDataSource($delegator));
+        $delegator->addDataSource($this->getFullDataSource($delegator, $guzzle));
+        $return = $guzzle->get('sites/{site}/tasks.json')->json();
+        $tasks = $delegator->getSites()[0]->getTasks();
+        $tasks_data = [];
+        foreach ($tasks as $id => $task) {
+            $tasks_data[$id] = $task->getData();
+        }
+        $this->assertEquals($return, $tasks_data);
+    }
+
+    public function testTask() {
+        $guzzle = new GuzzleTestClient();
+        $delegator = new DataSourceDelegator();
+        $delegator->addDataSource($this->getPartialDataSource($delegator));
+        $delegator->addDataSource($this->getFullDataSource($delegator, $guzzle));
+        $return = $guzzle->get('sites/{site}/tasks/{task}.json')->json();
+        $task = $delegator->getSites()[0]->getTask(1);
+        $this->assertEquals($return, $task->getData());
+        $this->assertEquals($return['id'], $task->getId());
+        $this->assertEquals($return['completed'], $task->getCompleted());
+        $this->assertEquals($return['created'], $task->getCreated());
+        $this->assertEquals($return['description'], $task->getDescription());
+        $this->assertEquals($return['logs'], $task->getLogs());
+        $this->assertEquals($return['queue'], $task->getQueue());
+        $this->assertEquals($return['result'], $task->getResult());
+        $this->assertEquals($return['sender'], $task->getSender());
+        $this->assertEquals($return['started'], $task->getStarted());
+        $this->assertEquals('devcloud:test0', $task->getSiteId());
+    }
+
+    public function testEnvs() {
+        $guzzle = new GuzzleTestClient();
+        $delegator = new DataSourceDelegator();
+        $delegator->addDataSource($this->getPartialDataSource($delegator));
+        $delegator->addDataSource($this->getFullDataSource($delegator, $guzzle));
+        $return = $guzzle->get('sites/{site}/envs.json')->json();
+        $envs = $delegator->getSites()[0]->getEnvs();
+        $envs_data = [];
+        foreach ($envs as $key => $env) {
+            $envs_data[$key] = $env->getData();
+        }
+        $this->assertEquals($return, $envs_data);
+    }
+
+    public function testEnv() {
+        $guzzle = new GuzzleTestClient();
+        $delegator = new DataSourceDelegator();
+        $delegator->addDataSource($this->getPartialDataSource($delegator));
+        $delegator->addDataSource($this->getFullDataSource($delegator, $guzzle));
+        $return = $guzzle->get('sites/{site}/envs/{env}.json')->json();
+        $env = $delegator->getSites()[0]->getEnv('test');
+        $this->assertEquals($return, $env->getData());
+        $this->assertEquals($return['name'], $env->getName());
+        $this->assertEquals($return['vcs_path'], $env->getVcsPath());
+        $this->assertEquals($return['ssh_host'], $env->getSshHost());
+        $this->assertEquals($return['db_clusters'], $env->getDbClusters());
+        $this->assertEquals($return['default_domain'], $env->getDefaultDomain());
+        $this->assertEquals($return['livedev'], $env->getLivedev());
+        $this->assertEquals('devcloud:test0', $env->getSiteId());
+        //$this->assertEquals($return, $env->getLogStream());
+    }
+}

--- a/tests/PartialDataSourceClient.php
+++ b/tests/PartialDataSourceClient.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @file
+ * Contains Acquia\Platform\Cloud\Tests\PartialDataSourceClient.
+ */
+
+namespace Acquia\Platform\Cloud\Tests;
+
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Message\Response;
+use GuzzleHttp\Stream\Stream;
+
+/**
+ * Similar to GuzzleTestClient, but throws exceptions for some DataSourceInterface methods
+ */
+class PartialDataSourceClient extends Client {
+
+  protected $task1 = [
+    'id' => '0000001',
+    'completed' => '1382380098',
+    'created' => '1382380094',
+    'description' => 'Create database test0 in Dev.',
+    'logs' => '',
+    'queue' => 'ah-callback',
+    'result' => '',
+    'sender' => 'DatabaseFactory::save',
+    'started' => '1382380094',
+    'state' => 'done',
+  ];
+
+  protected $task2 = [
+    'id' => '0000002',
+    'completed' => '1382380098',
+    'created' => '1382380094',
+    'description' => 'Create database test0 in Stage.',
+    'logs' => '',
+    'queue' => 'ah-callback',
+    'result' => '',
+    'sender' => 'DatabaseFactory::save',
+    'started' => '1382380096',
+    'state' => 'done',
+  ];
+
+  protected $env1 = [
+    'name' => 'dev2',
+    'vcs_path' => 'master',
+    'ssh_host' => 'free-4321.devcloud.hosting.acquia.com',
+    'db_clusters' =>
+      array (
+        0 => '3097',
+      ),
+    'default_domain' => 'otherdev.devcloud.acquia-sites.com',
+    'livedev' => 'enabled'
+  ];
+
+  protected $env2 = [
+    'name' => 'test2',
+    'vcs_path' => 'tags/WELCOME',
+    'ssh_host' => 'free-4321.devcloud.hosting.acquia.com',
+    'db_clusters' =>
+      array (
+        0 => '3097',
+      ),
+    'default_domain' => 'othertest.devcloud.acquia-sites.com',
+    'livedev' => 'enabled'
+  ];
+
+  public function get($url = null, $options = []) {
+    if (is_array($url)) {
+      $test = $url[0];
+    }
+    else {
+      $test = $url;
+    }
+    switch($test) {
+      case 'sites.json':
+        return $this->getResponse($this->getSites());
+      case 'sites/{site}.json':
+        return $this->getResponse($this->getSite());
+      case 'sites/{site}/tasks.json':
+        return $this->getResponse($this->getTasks());
+      case 'sites/{site}/tasks/{task}.json':
+        return $this->getResponse($this->getTask());
+      case 'sites/{site}/envs.json':
+        return $this->getResponse($this->getEnvs());
+      case 'sites/{site}/envs/{env}.json':
+        return $this->getResponse($this->getEnv());
+    }
+  }
+
+  protected function getResponse($body) {
+    $stream = Stream::factory($body);
+    $response = new Response(200);
+    $response->setBody($stream);
+    return $response;
+  }
+
+  protected function getSites() {
+    $json = json_encode([
+      0 => 'devcloud:test0',
+      1 => 'devcloud:test1',
+    ]);
+    return $json;
+  }
+
+  protected function getSite() {
+    throw new \RuntimeException(sprintf(
+        "Fatal: %s is not implemented!\n",
+        __METHOD__
+    ));
+  }
+
+  protected function getTasks() {
+    throw new \RuntimeException(sprintf(
+        "Fatal: %s is not implemented!\n",
+        __METHOD__
+    ));
+  }
+
+  protected function getTask() {
+    throw new \RuntimeException(sprintf(
+        "Fatal: %s is not implemented!\n",
+        __METHOD__
+    ));
+  }
+
+  protected function getEnvs() {
+    $envs = [
+        $this->env1,
+        $this->env2
+    ];
+    return json_encode($envs);
+  }
+
+  protected function getEnv() {
+    return json_encode($this->env1);
+  }
+}


### PR DESCRIPTION
- Added a DataSourceDelegator class implementing DataSourceInterface
 - Can have multiple data sources added.
 - Will attempt to delegate interface methods to each registered data source.
 - Data sources are iterated by weight from lowest to highest.
 - Returns the first successful response.
 - Throws a RuntimeException if no backends were successful.
- Added an optional "delegator" argument to Client constructor.
 - This is backward compatible with existing implementation (e.g. IntegrationTest) 
 - The Client factory method will supply the delegator as the dataSource if it was set (otherwise defaults to $this)
- Added DelegationTest class
 - Based on IntegrationTest, but illustrates the use of multiple data sources.